### PR TITLE
fix(hooks): map Copilot task/web_search in COPILOT_TOOL_MAP

### DIFF
--- a/__tests__/hooks/handler.test.ts
+++ b/__tests__/hooks/handler.test.ts
@@ -443,6 +443,8 @@ describe("hooks/handler", () => {
         ["rg", "Grep"],
         ["ls", "LS"],
         ["web_fetch", "WebFetch"],
+        ["task", "Task"],
+        ["web_search", "WebSearch"],
       ];
       for (const [raw, canonical] of cases) {
         vi.mocked(evaluatePolicies).mockResolvedValueOnce({

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -275,6 +275,12 @@ export const COPILOT_TOOL_MAP: Record<string, string> = {
   rg: "Grep",
   ls: "LS",
   web_fetch: "WebFetch",
+  // Documented Copilot tools that launch subagents / web search. Without these
+  // entries a policy matching `toolName === "Task"` (or `"WebSearch"`)
+  // silently never fires on Copilot — the worst failure mode for a guardrail.
+  // `ask_user` is intentionally unmapped: it has no filesystem or shell reach.
+  task: "Task",
+  web_search: "WebSearch",
 };
 
 /**


### PR DESCRIPTION
### Problem
`COPILOT_TOOL_MAP` in `src/hooks/types.ts` is missing documented Copilot tools `task` and `web_search`. Unmapped names pass through uncanonicalised, so a policy matching `toolName === "Task"` (or `"WebSearch"`) **silently never fires on Copilot**.

### Solution
- Add `task: "Task"` and `web_search: "WebSearch"` next to the existing `web_fetch: "WebFetch"` entry.
- Leave `ask_user` unmapped on purpose: it has no filesystem or shell reach, so it is not a guardrail surface. (Issue asked for a reasoned call either way.)
- Extend the existing COPILOT_TOOL_MAP cases table in `__tests__/hooks/handler.test.ts` so a Copilot `task` payload canonicalises to `Task` (and `web_search` → `WebSearch`).

### Issue alignment
- No maintainer design note on #690; follows the reporter's suggested map entries and Done-when criteria.
- Judgement call on `ask_user`: intentionally unmapped (documented in the map comment and this PR).

### Testing
- Command: `node node_modules/vitest/vitest.mjs run __tests__/hooks/handler.test.ts`
- Result: `59 passed` (includes `canonicalizes every Copilot tool name in COPILOT_TOOL_MAP` covering `task`/`web_search`)
- Also ran `__tests__/hooks/copilot-canonicalize.test.ts`: `8 passed`

### Agent dimension
tool-retrieval — tool-name canonicalisation so policy routing matches the Claude-canonical tool surface across CLIs.

### Core value
Copilot users who believe Task policies are protecting them were never protected — this closes that silent gap.

Fixes #690


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing Copilot `task` and `web_search` tools using their canonical names.
  * Built-in policies can now apply to these tools during Copilot sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->