### PR TITLE
[docs] Document self-serve workspace limit

### DIFF
--- a/docs/admin/users-and-organizations.mdx
+++ b/docs/admin/users-and-organizations.mdx
@@ -6,6 +6,8 @@ icon: "users"
 
 Organizations isolate sessions, evaluations, audits, issues, alerts, queries, dashboards, users, and keys. Confirm the active organization before changing administrative resources.
 
+On Failproof AI Cloud, a signed-in account can create up to 10 workspaces from the organization switcher. Each new workspace starts on the Free plan. Workspaces you join by invitation do not count toward that creation limit.
+
 ## Manage members and organizations
 
 <Tabs>


### PR DESCRIPTION
Documents that Cloud accounts can create up to 10 workspaces, that new workspaces start on Free, and that invited memberships do not count toward the creation limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for Failproof AI Cloud workspace creation limits.
  - Clarified that signed-in accounts can create up to 10 Free-plan workspaces, while workspaces joined by invitation do not count toward this limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->